### PR TITLE
Revert "Update dependency io.github.qdsfdhvh:image-loader to v1.8.2"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ kotlinx-serialization = "1.7.1"
 
 ktor = "2.3.12"
 
-image-loader = "1.8.2"
+image-loader = "1.8.1"
 ksoup = "0.4.0"
 okio = "3.9.0"
 


### PR DESCRIPTION
This reverts commit 2c7ebc4fdc92f1d67468080ea7312ffb4096b3c7.